### PR TITLE
Restoring with draft_id

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -25,9 +25,9 @@ class DraftsController < ApplicationController
   def restore
     @draft = Draft.find(params[:id])
     if @draft.element_id == 0
-      redirect_to({:controller => "issues", :action => "new", :project_id => params[:project_id].to_i}.merge(@draft.content))
+      redirect_to({:controller => "issues", :action => "new", :project_id => params[:project_id].to_i, :draft_id => @draft})
     else
-      redirect_to({:controller => "issues", :action => "edit", :id => @draft.element_id}.merge(@draft.content))
+      redirect_to({:controller => "issues", :action => "edit", :id => @draft.element_id, :draft_id => @draft})
     end
   end
   

--- a/init.rb
+++ b/init.rb
@@ -4,6 +4,7 @@ require 'drafts_issue_hook'
 
 config.to_prepare do
   require_dependency 'drafts_issue_patch'
+  require_dependency 'drafts_issues_patch'
 end
 
 Redmine::Plugin.register :redmine_drafts do

--- a/lib/drafts_issues_patch.rb
+++ b/lib/drafts_issues_patch.rb
@@ -1,0 +1,17 @@
+require_dependency 'issues_controller'
+
+class IssuesController
+  prepend_before_filter :set_draft
+
+  private
+
+    def set_draft
+      if params[:draft_id]
+        draft = Draft.find params[:draft_id] rescue nil
+        if draft
+          params.merge!(draft.content)
+        end
+      end
+    end
+end
+


### PR DESCRIPTION
I had troubles with the redirect way when issues had a long description. There were errors in parsing http headers and the restore didn't complete successfully.
My pull request includes a workaround for that
