### PR TITLE
Add support for restoring draft attachments

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -16,7 +16,7 @@ class DraftsController < ApplicationController
     if request.xhr? && has_to_be_saved
       @draft = Draft.find_or_create_for_issue(:user_id => User.current.id,
                                               :element_id => params[:issue_id].to_i)
-      new_content = params.reject{|k,v| !%w(issue notes).include?(k)}
+      new_content = params.reject{|k,v| !%w(issue notes attachments).include?(k)}
       unless @draft.content == new_content
         @draft.content = new_content
         if @draft.save

--- a/app/views/drafts/_issue_form.html.erb
+++ b/app/views/drafts/_issue_form.html.erb
@@ -19,6 +19,31 @@ $(function() {
   })
 })
 </script>
+<% if @draft_attachments %>
+  <script>
+    $(() => {
+      const attachmentInput = $("#new-attachments input[type=file]");
+      if (!attachmentInput.length) return;
+
+      const draftAttachments = <%= raw @draft_attachments.to_json %>;
+      draftAttachments.forEach((attachment) => {
+        if (!attachment) return;
+
+        restoreDraftFile(
+          attachmentInput,
+          attachment.filename,
+          attachment.description,
+          attachment.token,
+          attachment.path
+        );
+      });
+
+      <% if @failed_draft_attachments_count > 0 %>
+        alert("<%= l(:message_failed_to_restore_attachment, count: @failed_draft_attachments_count) %>");
+      <% end %>
+    });
+  </script>
+<% end %>
 <% end %>
 
 <div id="draft-status" style="display:none;"></div>

--- a/assets/javascripts/drafts.js
+++ b/assets/javascripts/drafts.js
@@ -1,0 +1,33 @@
+function restoreDraftFile(inputEl, fileName, attachmentDescription, attachmentToken, attachmentPath) {
+// Base on the original addFile function
+const attachmentsFields = $(inputEl).closest('.attachments_form').find('.attachments_fields');
+const addAttachment = $(inputEl).closest('.attachments_form').find('.add_attachment');
+const maxFiles = ($(inputEl).attr('multiple') == 'multiple' ? 10 : 1);
+
+const attachmentId = restoreDraftFile.nextAttachmentId++;
+addFile.nextAttachmentId = attachmentId;
+
+const fileSpan = $('<span>', { id: 'attachments_' + attachmentId });
+let param = $(inputEl).data('param');
+if (!param) {param = 'attachments'};
+
+fileSpan.append(
+    $('<input>', { type: 'text', 'class': 'icon icon-attachment filename readonly', name: param +'[' + attachmentId + '][filename]', readonly: 'readonly'} ).val(fileName),
+    $('<input>', { type: 'text', 'class': 'description', name: param + '[' + attachmentId + '][description]', maxlength: 255, placeholder: $(inputEl).data('description-placeholder') } ).val(attachmentDescription),
+    $('<input>', { type: 'hidden', 'class': 'token', name: param + '[' + attachmentId + '][token]'} ).val(attachmentToken),
+    $('<a>&nbsp</a>').attr({ href: "#", 'class': 'icon-only icon-del remove-upload' }).click(removeFile).attr({
+        "data-remote": true,
+        "data-method": 'delete',
+        href: attachmentPath
+        })
+        .off('click')
+).appendTo(attachmentsFields);
+
+if ($(inputEl).data('description') == 0) {
+fileSpan.find('input.description').remove();
+}
+
+addAttachment.toggle(attachmentsFields.children().length < maxFiles);
+return attachmentId;
+}
+restoreDraftFile.nextAttachmentId = 1;

--- a/assets/javascripts/drafts.js
+++ b/assets/javascripts/drafts.js
@@ -5,7 +5,7 @@ const addAttachment = $(inputEl).closest('.attachments_form').find('.add_attachm
 const maxFiles = ($(inputEl).attr('multiple') == 'multiple' ? 10 : 1);
 
 const attachmentId = restoreDraftFile.nextAttachmentId++;
-addFile.nextAttachmentId = attachmentId;
+addFile.nextAttachmentId = attachmentId + 1;
 
 const fileSpan = $('<span>', { id: 'attachments_' + attachmentId });
 let param = $(inputEl).data('param');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,6 @@ en:
   label_draft_pending: "Draft pending, saved %{time} ago : %{restore} or %{delete}"
   label_draft_restore: "restore"
   label_draft_delete: "delete"
+  message_failed_to_restore_attachment:
+    one: "Failed to restore 1 attachment."
+    other: "Failed to restore some attachments (%{count} files)."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,3 +4,6 @@ ja:
   label_draft_pending: "%{time}前に保存されたドラフトがあります。 : %{restore} or %{delete}"
   label_draft_restore: "復旧"
   label_draft_delete: "削除"
+  message_failed_to_restore_attachment:
+    one: "1件の添付ファイルの復旧に失敗しました。"
+    other: "一部の添付ファイル (%{count} 件) の復旧に失敗しました。"

--- a/lib/redmine_drafts/hooks.rb
+++ b/lib/redmine_drafts/hooks.rb
@@ -2,7 +2,7 @@ module RedmineDrafts
   class Hooks < Redmine::Hook::ViewListener
     # Add our own elements to issue show view (in show and form sections)
     #
-    # NB: This works too, maybe for future use if we have many things to 
+    # NB: This works too, maybe for future use if we have many things to
     # do before rendering :
     #
     #   def view_issues_form_details_bottom(context)
@@ -16,7 +16,8 @@ module RedmineDrafts
     # Add our css/js on each page
     def view_layouts_base_html_head(context)
       stylesheet_link_tag("drafts", :plugin => "redmine_drafts") +
-        javascript_include_tag('jquery.observe-form.js', :plugin => 'redmine_drafts')
+        javascript_include_tag('jquery.observe-form.js', :plugin => 'redmine_drafts') +
+        javascript_include_tag('drafts.js', :plugin => 'redmine_drafts')
     end
 
     class ModelHook < Redmine::Hook::Listener

--- a/lib/redmine_drafts/issues_controller_patch.rb
+++ b/lib/redmine_drafts/issues_controller_patch.rb
@@ -5,7 +5,8 @@ module RedmineDrafts::IssuesControllerPatch
     if params[:draft_id].present?
       draft = Draft.find(params[:draft_id]) rescue nil
       if draft.present?
-        @draft_attachments = prepare_draft_attachments(draft.content["attachments"].permit!.to_h)
+        attachment_params = draft.content["attachments"]
+        @draft_attachments = prepare_draft_attachments(attachment_params.permit!.to_h) if attachment_params.present?
         params.merge!(draft.content.reject{|k,v| k == "attachments"}.permit!)
       end
     end

--- a/lib/redmine_drafts/issues_controller_patch.rb
+++ b/lib/redmine_drafts/issues_controller_patch.rb
@@ -5,9 +5,34 @@ module RedmineDrafts::IssuesControllerPatch
     if params[:draft_id].present?
       draft = Draft.find(params[:draft_id]) rescue nil
       if draft.present?
-        params.merge!(draft.content.permit!)
+        @draft_attachments = prepare_draft_attachments(draft.content["attachments"].permit!.to_h)
+        params.merge!(draft.content.reject{|k,v| k == "attachments"}.permit!)
       end
     end
+  end
+
+  private
+
+  def prepare_draft_attachments(draft_params)
+    return [] unless draft_params.present?
+
+    attachments = draft_params.map do |_, param|
+      token = param['token']
+      attachment_id = token.split('.').first
+      attachment = Attachment.find_by(id: attachment_id)
+
+      next nil unless attachment
+
+      {
+        filename: attachment.filename,
+        description: attachment.description,
+        token: token,
+        path: attachment_path(attachment, format: 'js')
+      }
+    end
+
+    @failed_draft_attachments_count = attachments.count(nil)
+    attachments.compact
   end
 end
 
@@ -18,4 +43,3 @@ class IssuesController
   prepend_before_action :set_draft, :only => [:new, :edit]
 
 end
-


### PR DESCRIPTION
This PR adds support for restoring draft attachments. It ensures that attachments saved in drafts can be restored when editing an issue, improving user experience.

### Changes
- Updated `DraftsController` to include attachments when saving drafts.
- Modified `IssuesController patch` to restore draft attachments when loading a draft.
- Updated the issue form hook and added `drafts.js` to restore draft attachments in the issue form.
- Ensured failed attachment restorations are counted and displayed as an alert.